### PR TITLE
Fixed a typo

### DIFF
--- a/games/doom/pickups.lua
+++ b/games/doom/pickups.lua
@@ -86,7 +86,7 @@ DOOM.PICKUPS =
     cluster = { 3,7 },
     give = { {health=1} },
     storage_prob = 20,
-    stroage_qty = 5
+    storage_qty = 5
   },
 
   -- AMMO --


### PR DESCRIPTION
"storage_qty" was typoed under the armor bonus entry.